### PR TITLE
Fixed production_capability showing too high values by a factor of 10

### DIFF
--- a/Source/com.sonnen.battery/drivers/sonnenbatterie/device.ts
+++ b/Source/com.sonnen.battery/drivers/sonnenbatterie/device.ts
@@ -101,7 +101,7 @@ class BatteryDevice extends Homey.Device {
       
       this.setCapabilityValue("meter_power", +latestStateJson.Consumption_W / 1000); // = consumption
       this.setCapabilityValue("measure_battery", +latestStateJson.USOC); // Percentage on battery
-      this.setCapabilityValue("production_capability", +latestStateJson.Production_W / 100);
+      this.setCapabilityValue("production_capability", +latestStateJson.Production_W / 1000);
       this.setCapabilityValue("capacity_capability", `${(+latestStateJson.FullChargeCapacity)/1000} kWh` );
       this.setCapabilityValue("feed_grid_capability", -1 * (+latestStateJson.GridFeedIn_W / 1000)); // GridFeedIn_W  : from grid
       this.setCapabilityValue("consumption_capability", +latestStateJson.Consumption_W / 1000); // Consumption_W : consumption


### PR DESCRIPTION
After installing the app and comparing the values for the current solar production I was wondering why it always showed values like 22.00 kW despite my PV could never produce that high values. So actually that should be just 2200 W. Looking into the code apparently all values got devided by 1000, but this one just by 100 explaining the factor of 10.