### PR TITLE
Improve energy

### DIFF
--- a/Source/com.sonnen.battery/.homeychangelog.json
+++ b/Source/com.sonnen.battery/.homeychangelog.json
@@ -72,6 +72,6 @@
     "en": "Bring back internal-batteries."
   },
   "1.4.0": {
-    "en": "Allow sonnenBatterie to meter imported & exported energy. Be sure to exclude e.g. an additional solar panel inverter from Homey energy to avoid that multiple devices report household totals and wrongly all those values add up."
+    "en": "Allow sonnenBatterie to meter imported & exported energy for Energy tab on supported hardware. Fixed measure_power to show charging/discharging as positive/negative values and removing battery charging state."
   }
 }

--- a/Source/com.sonnen.battery/.homeychangelog.json
+++ b/Source/com.sonnen.battery/.homeychangelog.json
@@ -70,5 +70,8 @@
   },
   "1.3.1": {
     "en": "Bring back internal-batteries."
+  },
+  "1.4.0": {
+    "en": "Allow sonnenBatterie to meter imported & exported energy. Be sure to exclude e.g. an additional solar panel inverter from Homey energy to avoid that multiple devices report household totals and wrongly all those values add up."
   }
 }

--- a/Source/com.sonnen.battery/.homeycompose/app.json
+++ b/Source/com.sonnen.battery/.homeycompose/app.json
@@ -1,6 +1,6 @@
 {
   "id": "com.sonnen.battery",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "compatibility": ">=12.2.0",
   "sdk": 3,
   "platforms": [

--- a/Source/com.sonnen.battery/app.json
+++ b/Source/com.sonnen.battery/app.json
@@ -1,7 +1,7 @@
 {
   "_comment": "This file is generated. Please edit .homeycompose/app.json instead.",
   "id": "com.sonnen.battery",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "compatibility": ">=12.2.0",
   "sdk": 3,
   "platforms": [
@@ -531,7 +531,9 @@
         "state_bms_capability",
         "alarm_generic",
         "button.reset_meter",
-        "battery_charging_state"
+        "battery_charging_state",
+        "meter_power.imported",
+        "meter_power.exported"
       ],
       "capabilitiesOptions": {
         "button.reset_meter": {
@@ -544,13 +546,26 @@
             "en": "Resets today's totals (kWh). This can not be restored.",
             "de": "Setzt die heutigen Gesamtsummen (kWh) zurück. Dies kann nicht rückgängig gemacht werden."
           }
+        },
+        "meter_power.imported": {
+          "title": {
+            "en": "Imported Energy"
+          }
+        },
+        "meter_power.exported": {
+          "title": {
+            "en": "Exported Energy"
+          }
         }
       },
       "energy": {
         "homeBattery": true,
         "batteries": [
           "INTERNAL"
-        ]
+        ],
+        "cumulative": true,
+        "cumulativeImportedCapability": "meter_power.imported",
+        "cumulativeExportedCapability": "meter_power.exported"
       },
       "platforms": [
         "local"

--- a/Source/com.sonnen.battery/app.json
+++ b/Source/com.sonnen.battery/app.json
@@ -531,9 +531,7 @@
         "state_bms_capability",
         "alarm_generic",
         "button.reset_meter",
-        "battery_charging_state",
-        "meter_power.imported",
-        "meter_power.exported"
+        "battery_charging_state"
       ],
       "capabilitiesOptions": {
         "button.reset_meter": {
@@ -546,12 +544,6 @@
             "en": "Resets today's totals (kWh). This can not be restored.",
             "de": "Setzt die heutigen Gesamtsummen (kWh) zurück. Dies kann nicht rückgängig gemacht werden."
           }
-        },
-        "meter_power.imported": {
-          "uiComponent": null
-        },
-        "meter_power.exported": {
-          "uiComponent": null
         }
       },
       "energy": {
@@ -559,9 +551,7 @@
         "batteries": [
           "INTERNAL"
         ],
-        "cumulative": true,
-        "cumulativeImportedCapability": "meter_power.imported",
-        "cumulativeExportedCapability": "meter_power.exported"
+        "cumulative": true
       },
       "platforms": [
         "local"

--- a/Source/com.sonnen.battery/app.json
+++ b/Source/com.sonnen.battery/app.json
@@ -549,8 +549,7 @@
         "homeBattery": true,
         "batteries": [
           "INTERNAL"
-        ],
-        "cumulative": true
+        ]
       },
       "platforms": [
         "local"

--- a/Source/com.sonnen.battery/app.json
+++ b/Source/com.sonnen.battery/app.json
@@ -530,8 +530,7 @@
         "state_inverter_capability",
         "state_bms_capability",
         "alarm_generic",
-        "button.reset_meter",
-        "battery_charging_state"
+        "button.reset_meter"
       ],
       "capabilitiesOptions": {
         "button.reset_meter": {

--- a/Source/com.sonnen.battery/app.json
+++ b/Source/com.sonnen.battery/app.json
@@ -548,14 +548,10 @@
           }
         },
         "meter_power.imported": {
-          "title": {
-            "en": "Imported Energy"
-          }
+          "uiComponent": null
         },
         "meter_power.exported": {
-          "title": {
-            "en": "Exported Energy"
-          }
+          "uiComponent": null
         }
       },
       "energy": {

--- a/Source/com.sonnen.battery/drivers/sonnenbatterie/device.ts
+++ b/Source/com.sonnen.battery/drivers/sonnenbatterie/device.ts
@@ -278,7 +278,8 @@ class BatteryDevice extends Homey.Device {
         `${+latestStateJson.FullChargeCapacity / 1000} kWh`
       );
 
-      // meter: Wh, measure: W
+      // meter: Wh, measure: W - default units would be kWh in the UI
+      // but disabled both as using grid_feed_in_daily_capability and grid_consumption_daily_capability already.
       this.setCapabilityValue('meter_power.exported', currentState.totalGridFeedIn_Wh / 1000);
       this.setCapabilityValue('meter_power.imported', currentState.totalGridConsumption_Wh /1000);
 

--- a/Source/com.sonnen.battery/drivers/sonnenbatterie/device.ts
+++ b/Source/com.sonnen.battery/drivers/sonnenbatterie/device.ts
@@ -277,11 +277,13 @@ class BatteryDevice extends Homey.Device {
         'capacity_capability',
         `${+latestStateJson.FullChargeCapacity / 1000} kWh`
       );
+
+      // meter: Wh, measure: W
+      this.setCapabilityValue('meter_power.exported', currentState.totalGridFeedIn_Wh / 1000);
+      this.setCapabilityValue('meter_power.imported', currentState.totalGridConsumption_Wh /1000);
+
       this.setCapabilityValue('grid_feed_in_capability', grid_feed_in_W / 1000); // GridFeedIn_W positive: to grid
-      this.setCapabilityValue(
-        'grid_consumption_capability',
-        grid_consumption_W / 1000
-      ); // GridFeedIn_W negative: from grid
+      this.setCapabilityValue('grid_consumption_capability', grid_consumption_W / 1000); // GridFeedIn_W negative: from grid
       this.setCapabilityValue(
         'consumption_capability',
         +statusJson.Consumption_W / 1000

--- a/Source/com.sonnen.battery/drivers/sonnenbatterie/device.ts
+++ b/Source/com.sonnen.battery/drivers/sonnenbatterie/device.ts
@@ -130,6 +130,36 @@ class BatteryDevice extends Homey.Device {
     if (this.hasCapability('battery_charging_state') === false) {
       await this.addCapability('battery_charging_state');
     }
+
+    // v1.4.0
+    this.log("Homey version:", this.homey.version); // software version won't help
+    this.log("Homey plattform: ", this.homey.platformVersion); // Homey 2019 = 1...
+    
+    //"cumulativeImportedCapability": "meter_power.imported",
+    //"cumulativeExportedCapability": "meter_power.exported"
+
+   // "meter_power.imported": {
+   //   "uiComponent": null
+   // },
+   // "meter_power.exported": {
+   //   "uiComponent": null
+   // }
+
+   // Homey Pro (early 2019) emits this, so need to dynamically apply the energy settings
+   // Warning: drivers.sonnenbatterie has energy.cumulative set to true, but is missing 'cumulativeImportedCapability'. Disregard this warning if the driver does not have `meter_power` capabilities.
+   // Warning: drivers.sonnenbatterie has energy.cumulative set to true, but is missing 'cumulativeExportedCapability'. Disregard this warning if the driver does not have `meter_power` capabilities.
+
+
+    if (this.hasCapability('meter_power.imported') === false) {
+      await this.addCapability('meter_power.imported');
+    
+    }
+    await this.setCapabilityOptions("meter_power.imported", { "uiComponent": null });
+    if (this.hasCapability('meter_power.exported') === false) {
+      await this.addCapability('meter_power.exported');
+      
+    }
+    await this.setCapabilityOptions("meter_power.exported", { "uiComponent": null });
   }
 
   /**

--- a/Source/com.sonnen.battery/drivers/sonnenbatterie/device.ts
+++ b/Source/com.sonnen.battery/drivers/sonnenbatterie/device.ts
@@ -61,42 +61,37 @@ class BatteryDevice extends Homey.Device {
     this.log('Current energy config: ', energy, this.homey.platform, this.homey.platformVersion);
 
     if (this.homey.platform === 'cloud' || this.homey.platformVersion >= 2 /* Homey Pro (early 2023) or later */) {
-      if (energy.cumulative !== true) {
-        this.log('Configure meter_power.imported & meter_power.exported');
-        energy.cumulative = true;
-        energy.cumulativeImportedCapability = 'meter_power.imported';
-        energy.cumulativeExportedCapability = 'meter_power.exported';
-        await this.setEnergy(energy);
-      
-        if (this.hasCapability('meter_power.imported') === false) {
-          await this.addCapability('meter_power.imported');     
-          await this.setCapabilityOptions('meter_power.imported', {    
-            'title': {
-              'en': 'Imported Power',
-              'de': 'Importierte Energie'
-            }
-          })
-        }
-      
-        if (this.hasCapability('meter_power.exported') === false) {
-          await this.addCapability('meter_power.exported')
-          await this.setCapabilityOptions('meter_power.exported', { 
-            'title': {
-              'en': 'Exported Power',
-              'de': 'Exportierte Energie'
-            }
-          }) 
-        }
-        this.log('Applied updated energy settings: ', this.getEnergy());
-      } 
-    } else {
-      this.log('This Homey does not support meter_power.imported & meter_power.exported');  
-      if (energy.cumulative !== true) {
-        energy.cumulative = true;
-        await this.setEnergy(energy);
-        this.log('Applied updated energy settings: ', this.getEnergy());
+      this.log('Configure meter_power.imported & meter_power.exported');
+      energy.cumulative = true;
+      energy.cumulativeImportedCapability = 'meter_power.imported';
+      energy.cumulativeExportedCapability = 'meter_power.exported';
+      await this.setEnergy(energy);
+    
+      if (this.hasCapability('meter_power.imported') === false) {
+        await this.addCapability('meter_power.imported');     
+        await this.setCapabilityOptions('meter_power.imported', {    
+          'title': {
+            'en': 'Imported Power',
+            'de': 'Importierte Energie'
+          }
+        })
       }
+    
+      if (this.hasCapability('meter_power.exported') === false) {
+        await this.addCapability('meter_power.exported')
+        await this.setCapabilityOptions('meter_power.exported', { 
+          'title': {
+            'en': 'Exported Power',
+            'de': 'Exportierte Energie'
+          }
+        }) 
+      }   
+    } else {
+      this.log('This Homey does not support meter_power.imported & meter_power.exported');    
+      energy.cumulative = true;
+      await this.setEnergy(energy);
     }
+    this.log('Applied updated energy settings: ', this.getEnergy());
   }
 
   /**

--- a/Source/com.sonnen.battery/drivers/sonnenbatterie/device.ts
+++ b/Source/com.sonnen.battery/drivers/sonnenbatterie/device.ts
@@ -133,7 +133,7 @@ class BatteryDevice extends Homey.Device {
 
     // v1.4.0
     this.log("Homey version:", this.homey.version); // software version won't help
-    this.log("Homey plattform: ", this.homey.platformVersion); // Homey 2019 = 1...
+    this.log("Homey plattform: ", this.homey.platformVersion); // Homey 2019 = 1... Homey 2023 = 2
     
     //"cumulativeImportedCapability": "meter_power.imported",
     //"cumulativeExportedCapability": "meter_power.exported"

--- a/Source/com.sonnen.battery/drivers/sonnenbatterie/device.ts
+++ b/Source/com.sonnen.battery/drivers/sonnenbatterie/device.ts
@@ -66,16 +66,26 @@ class BatteryDevice extends Homey.Device {
       energy.cumulativeExportedCapability = "meter_power.exported";
       await this.setEnergy(energy);
 
-      if (this.hasCapability('meter_power.imported') === false) {
-        await this.addCapability('meter_power.imported');
+      //if (this.hasCapability('meter_power.imported') === false) {
+        await this.addCapability('meter_power.imported').catch((err) => this.log("Error adding capability", err));
          // meter_power.imported is redundant to grid_consumption_daily_capability but unvailable on older Homeys
-        await this.setCapabilityOptions("meter_power.imported", { "uiComponent": null }); // make invisible in tab
-      }
-      if (this.hasCapability('meter_power.exported') === false) {
-        await this.addCapability('meter_power.exported');
+        await this.setCapabilityOptions("meter_power.imported", {    
+          "title": {
+            "en": "Imported Power",
+            "de": "Importierte Energie"
+          }
+        }).catch((err) => this.log("Error setting capability options", err));
+      //}
+      //if (this.hasCapability('meter_power.exported') === false) {
+        await this.addCapability('meter_power.exported').catch((err) => this.log("Error adding capability", err));
          // meter_power.exported is redundant to grid_feed_in_daily_capability but unvailable on older Homeys
-        await this.setCapabilityOptions("meter_power.exported", { "uiComponent": null }); // make invisible in tab
-      }
+        await this.setCapabilityOptions("meter_power.exported", { 
+          "title": {
+            "en": "Exported Power",
+            "de": "Exportierte Energie"
+          }
+        }).catch((err) => this.log("Error setting capability options", err));; 
+      //}
     } else {
       this.log("This Homey does not support meter_power.imported & meter_power.exported");  
     }
@@ -319,7 +329,7 @@ class BatteryDevice extends Homey.Device {
         'consumption_capability',
         +statusJson.Consumption_W / 1000
       ); // Consumption_W : consumption
-      this.setCapabilityValue('measure_power', +statusJson.Consumption_W);
+      this.setCapabilityValue('measure_power', -statusJson.Pac_total_W); // inverted to match the Homey Energy (positive = charging, negative = discharging)
       this.setCapabilityValue('number_battery_capability', numberBatteries);
       this.setCapabilityValue(
         'eclipse_capability',

--- a/Source/com.sonnen.battery/drivers/sonnenbatterie/driver.compose.json
+++ b/Source/com.sonnen.battery/drivers/sonnenbatterie/driver.compose.json
@@ -41,8 +41,7 @@
   },
   "energy": {
     "homeBattery": true,
-    "batteries": [ "INTERNAL" ],
-    "cumulative": true
+    "batteries": [ "INTERNAL" ]
   },
   "platforms": [
     "local"

--- a/Source/com.sonnen.battery/drivers/sonnenbatterie/driver.compose.json
+++ b/Source/com.sonnen.battery/drivers/sonnenbatterie/driver.compose.json
@@ -26,8 +26,7 @@
     "state_inverter_capability",
     "state_bms_capability",    
     "alarm_generic",
-    "button.reset_meter",
-    "battery_charging_state"
+    "button.reset_meter"
   ],
   "capabilitiesOptions": {
     "button.reset_meter": {

--- a/Source/com.sonnen.battery/drivers/sonnenbatterie/driver.compose.json
+++ b/Source/com.sonnen.battery/drivers/sonnenbatterie/driver.compose.json
@@ -27,7 +27,9 @@
     "state_bms_capability",    
     "alarm_generic",
     "button.reset_meter",
-    "battery_charging_state"
+    "battery_charging_state",
+    "meter_power.imported",
+    "meter_power.exported"
   ],
   "capabilitiesOptions": {
     "button.reset_meter": {
@@ -38,11 +40,20 @@
       "desc": { 
           "en": "Resets today's totals (kWh). This can not be restored.", 
           "de": "Setzt die heutigen Gesamtsummen (kWh) zurück. Dies kann nicht rückgängig gemacht werden." }
+    },
+    "meter_power.imported": {
+      "title": { "en": "Imported Energy" }
+    },
+    "meter_power.exported": {
+      "title": { "en": "Exported Energy" }
     }
   },
   "energy": {
     "homeBattery": true,
-    "batteries": [ "INTERNAL" ]
+    "batteries": [ "INTERNAL" ],
+    "cumulative": true,
+    "cumulativeImportedCapability": "meter_power.imported",
+    "cumulativeExportedCapability": "meter_power.exported"
   },
   "platforms": [
     "local"

--- a/Source/com.sonnen.battery/drivers/sonnenbatterie/driver.compose.json
+++ b/Source/com.sonnen.battery/drivers/sonnenbatterie/driver.compose.json
@@ -42,10 +42,10 @@
           "de": "Setzt die heutigen Gesamtsummen (kWh) zurück. Dies kann nicht rückgängig gemacht werden." }
     },
     "meter_power.imported": {
-      "title": { "en": "Imported Energy" }
+      "uiComponent": null
     },
     "meter_power.exported": {
-      "title": { "en": "Exported Energy" }
+      "uiComponent": null
     }
   },
   "energy": {

--- a/Source/com.sonnen.battery/drivers/sonnenbatterie/driver.compose.json
+++ b/Source/com.sonnen.battery/drivers/sonnenbatterie/driver.compose.json
@@ -27,9 +27,7 @@
     "state_bms_capability",    
     "alarm_generic",
     "button.reset_meter",
-    "battery_charging_state",
-    "meter_power.imported",
-    "meter_power.exported"
+    "battery_charging_state"
   ],
   "capabilitiesOptions": {
     "button.reset_meter": {
@@ -40,20 +38,12 @@
       "desc": { 
           "en": "Resets today's totals (kWh). This can not be restored.", 
           "de": "Setzt die heutigen Gesamtsummen (kWh) zurück. Dies kann nicht rückgängig gemacht werden." }
-    },
-    "meter_power.imported": {
-      "uiComponent": null
-    },
-    "meter_power.exported": {
-      "uiComponent": null
     }
   },
   "energy": {
     "homeBattery": true,
     "batteries": [ "INTERNAL" ],
-    "cumulative": true,
-    "cumulativeImportedCapability": "meter_power.imported",
-    "cumulativeExportedCapability": "meter_power.exported"
+    "cumulative": true
   },
   "platforms": [
     "local"

--- a/Source/com.sonnen.battery/package-lock.json
+++ b/Source/com.sonnen.battery/package-lock.json
@@ -61,9 +61,9 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/axios": {
-      "version": "1.7.7",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
-      "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.4.tgz",
+      "integrity": "sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
@@ -216,9 +216,9 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "axios": {
-      "version": "1.7.7",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
-      "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.4.tgz",
+      "integrity": "sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==",
       "requires": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",

--- a/Source/package-lock.json
+++ b/Source/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "Source",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "Homey.Sonnen",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
Cumulative flag added and some other properties, but only if newer Homey Pro 2023.
Does the trick to let sonnenBatterie report the total household consumption on Homey Pro 2019 & 2023. What the imported/exported meters are good for... Don't know yet. They are redundant anyway with the current daily totals. They are set anyway, if supported on HP 2023, but made invisible. Not really sure what the values could be good for. Maybe it's useful if one didn't have some totals already or only want to support newer HPs?
Also removed the battery_charging_state of 1.3.0. as it was always empty (unless it's somehow set based on the charge/discharge measurements)
Also note: I had a SolarEdge inverter also being part of the Homey Energy. This inverter also provided current solar power. And that one added up to the houldhold consumption that the battery reported. So solar production (SolarEdge) + household consumption (sonnenBatterie) which is pointless. But one can disable that and just have one SmartMeter device, i.e. the SB.