### PR TITLE
Fix: Trim whitespace from time input in time-of-use flow

### DIFF
--- a/Source/com.sonnen.battery/drivers/sonnenbatterie/driver.ts
+++ b/Source/com.sonnen.battery/drivers/sonnenbatterie/driver.ts
@@ -70,7 +70,7 @@ module.exports = class SonnenBatterieDriver extends SonnenDriver {
   };
 
   private async handleSetTimeOfUseByStartTimeAndHours(args: { device: BatteryDevice, start: string, hours: number, max_power: number }): Promise<void> {
-    const timeStart = args.start;
+    const timeStart = args.start.trim();
     const hours = args.hours;
     const maxPower = args.max_power;
 


### PR DESCRIPTION
Fixes issue where leading/trailing whitespace in time input (e.g. ' 15:36' from Android) causes parsing errors.

Simply adds .trim() to remove whitespace before processing.