### PR TITLE
Add grouping for minor and patch dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,8 @@ updates:
     rebase-strategy: "auto"
     # Limit concurrent PRs to prevent overwhelming
     open-pull-requests-limit: 10
+    groups:
+      minor-and-patch-dependencies:
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
As having a PR opened for each and every minor or patch update of a dependency by dependabot, this PR will change the dependabot config slightly to group those minor/patch changes together and collect that into one PR, potentially updating it. So one can basically merge the PR and have all collected updates at once while e.g. working on new features. 
Should balance between staying up-to-date with little effort while not cluttering the list of PRs. At least in my fork, it worked nicely for a couple of days to aggregate several updates into one PR which is why I could discard other "single version update" PRs meanwhile.